### PR TITLE
feat: add skill rendering with <skill>name</skill> syntax

### DIFF
--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -26,6 +26,18 @@
       },
       "additionalProperties": false
     },
+    "experimental": {
+      "type": "object",
+      "description": "Experimental features (may change or be removed in future versions)",
+      "properties": {
+        "skillRendering": {
+          "$ref": "#/definitions/booleanSetting",
+          "default": false,
+          "description": "Enable skill rendering with <skill>name</skill> or <skill name=\"name\" /> syntax. When enabled, skill tags are replaced with the skill's content body. Skills are loaded from OpenCode's standard skill directories."
+        }
+      },
+      "additionalProperties": false
+    },
     "installSkill": {
       "$ref": "#/definitions/booleanSetting",
       "default": true,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -63,6 +63,7 @@ describe("config", () => {
 
       expect(config).toEqual({
         logging: { debug: false },
+        experimental: { skillRendering: false },
         installSkill: true,
         hideCommandInOutput: false,
       });
@@ -200,6 +201,7 @@ describe("config", () => {
       // Should return defaults when config is invalid
       expect(config).toEqual({
         logging: { debug: false },
+        experimental: { skillRendering: false },
         installSkill: true,
         hideCommandInOutput: false,
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,11 +17,22 @@ export interface LoggingConfig {
 }
 
 /**
+ * Experimental features configuration
+ */
+export interface ExperimentalConfig {
+  /** Enable skill rendering with <skill>name</skill> or <skill name="name" /> syntax */
+  skillRendering: boolean;
+}
+
+/**
  * Configuration schema for the snippets plugin
  */
 export interface SnippetsConfig {
   /** Logging settings */
   logging: LoggingConfig;
+
+  /** Experimental features */
+  experimental: ExperimentalConfig;
 
   /** Automatically install SKILL.md to global skill directory */
   installSkill: boolean;
@@ -37,6 +48,9 @@ interface RawConfig {
   logging?: {
     debug?: BooleanSetting;
   };
+  experimental?: {
+    skillRendering?: BooleanSetting;
+  };
   installSkill?: BooleanSetting;
   hideCommandInOutput?: BooleanSetting;
 }
@@ -47,6 +61,9 @@ interface RawConfig {
 const DEFAULT_CONFIG: SnippetsConfig = {
   logging: {
     debug: false,
+  },
+  experimental: {
+    skillRendering: false,
   },
   installSkill: true,
   hideCommandInOutput: false,
@@ -66,6 +83,16 @@ const DEFAULT_CONFIG_CONTENT = `{
     // Values: true, false, "enabled", "disabled"
     // Default: false
     "debug": false
+  },
+
+  // Experimental features (may change or be removed)
+  "experimental": {
+    // Enable skill rendering with <skill>name</skill> or <skill name="name" /> syntax
+    // When enabled, skill tags are replaced with the skill's content body
+    // Skills are loaded from OpenCode's standard skill directories
+    // Values: true, false, "enabled", "disabled"
+    // Default: false
+    "skillRendering": false
   },
 
   // Automatically install SKILL.md to global skill directory
@@ -172,6 +199,7 @@ export function loadConfig(projectDir?: string): SnippetsConfig {
 
   logger.debug("Final config", {
     loggingDebug: config.logging.debug,
+    experimentalSkillRendering: config.experimental.skillRendering,
     installSkill: config.installSkill,
     hideCommandInOutput: config.hideCommandInOutput,
   });
@@ -184,12 +212,17 @@ export function loadConfig(projectDir?: string): SnippetsConfig {
  */
 function mergeConfig(base: SnippetsConfig, raw: RawConfig): SnippetsConfig {
   const debugValue = normalizeBooleanSetting(raw.logging?.debug);
+  const skillRenderingValue = normalizeBooleanSetting(raw.experimental?.skillRendering);
   const installSkillValue = normalizeBooleanSetting(raw.installSkill);
   const hideCommandValue = normalizeBooleanSetting(raw.hideCommandInOutput);
 
   return {
     logging: {
       debug: debugValue !== undefined ? debugValue : base.logging.debug,
+    },
+    experimental: {
+      skillRendering:
+        skillRenderingValue !== undefined ? skillRenderingValue : base.experimental.skillRendering,
     },
     installSkill: installSkillValue !== undefined ? installSkillValue : base.installSkill,
     hideCommandInOutput:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,14 @@ export const PATTERNS = {
 
   /** Matches shell commands like !`command` */
   SHELL_COMMAND: /!`([^`]+)`/g,
+
+  /**
+   * Matches skill tags in two formats:
+   * 1. Self-closing: <skill name="skill-name" /> or <skill name='skill-name'/>
+   * 2. Block format: <skill>skill-name</skill>
+   */
+  SKILL_TAG_SELF_CLOSING: /<skill\s+name=["']([^"']+)["']\s*\/>/gi,
+  SKILL_TAG_BLOCK: /<skill>([^<]+)<\/skill>/gi,
 } as const;
 
 /**

--- a/src/skill-loader.ts
+++ b/src/skill-loader.ts
@@ -1,0 +1,160 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import matter from "gray-matter";
+import { logger } from "./logger.js";
+
+/**
+ * Loaded skill info
+ */
+export interface SkillInfo {
+  /** The skill name */
+  name: string;
+  /** The skill content body (markdown, excluding frontmatter) */
+  content: string;
+  /** Optional description from frontmatter */
+  description?: string;
+  /** Where the skill was loaded from */
+  source: "global" | "project";
+  /** Full path to the skill file */
+  filePath: string;
+}
+
+/**
+ * Skill registry that maps skill names to their info
+ */
+export type SkillRegistry = Map<string, SkillInfo>;
+
+/**
+ * OpenCode skill directory patterns (in order of priority)
+ *
+ * Global paths:
+ * - ~/.config/opencode/skill/<name>/SKILL.md
+ * - ~/.config/opencode/skills/<name>/SKILL.md
+ *
+ * Project paths (higher priority):
+ * - .opencode/skill/<name>/SKILL.md
+ * - .opencode/skills/<name>/SKILL.md
+ * - .claude/skills/<name>/SKILL.md (Claude Code compatibility)
+ */
+const GLOBAL_SKILL_DIRS = [
+  join(homedir(), ".config", "opencode", "skill"),
+  join(homedir(), ".config", "opencode", "skills"),
+];
+
+function getProjectSkillDirs(projectDir: string): string[] {
+  return [
+    join(projectDir, ".opencode", "skill"),
+    join(projectDir, ".opencode", "skills"),
+    join(projectDir, ".claude", "skills"),
+  ];
+}
+
+/**
+ * Loads all skills from global and project directories
+ *
+ * @param projectDir - Optional project directory path
+ * @returns A map of skill names (lowercase) to their SkillInfo
+ */
+export async function loadSkills(projectDir?: string): Promise<SkillRegistry> {
+  const skills: SkillRegistry = new Map();
+
+  // Load from global directories first
+  for (const dir of GLOBAL_SKILL_DIRS) {
+    await loadFromDirectory(dir, skills, "global");
+  }
+
+  // Load from project directories (overrides global)
+  if (projectDir) {
+    for (const dir of getProjectSkillDirs(projectDir)) {
+      await loadFromDirectory(dir, skills, "project");
+    }
+  }
+
+  logger.debug("Skills loaded", { count: skills.size });
+  return skills;
+}
+
+/**
+ * Loads skills from a specific directory
+ */
+async function loadFromDirectory(
+  dir: string,
+  registry: SkillRegistry,
+  source: "global" | "project",
+): Promise<void> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const skill = await loadSkill(dir, entry.name, source);
+      if (skill) {
+        registry.set(skill.name.toLowerCase(), skill);
+      }
+    }
+
+    logger.debug(`Loaded skills from ${source} directory`, { path: dir });
+  } catch {
+    // Directory doesn't exist or can't be read - that's fine
+    logger.debug(`${source} skill directory not found`, { path: dir });
+  }
+}
+
+/**
+ * Loads a single skill from its directory
+ *
+ * @param baseDir - Base skill directory
+ * @param skillName - Name of the skill (directory name)
+ * @param source - Whether this is a global or project skill
+ * @returns The parsed skill info, or null if not found/invalid
+ */
+async function loadSkill(
+  baseDir: string,
+  skillName: string,
+  source: "global" | "project",
+): Promise<SkillInfo | null> {
+  const filePath = join(baseDir, skillName, "SKILL.md");
+
+  try {
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) {
+      return null;
+    }
+
+    const fileContent = await file.text();
+    const parsed = matter(fileContent);
+
+    const content = parsed.content.trim();
+    const frontmatter = parsed.data as { name?: string; description?: string };
+
+    // Use frontmatter name if available, otherwise use directory name
+    const name = frontmatter.name || skillName;
+
+    return {
+      name,
+      content,
+      description: frontmatter.description,
+      source,
+      filePath,
+    };
+  } catch (error) {
+    logger.warn("Failed to load skill", {
+      skillName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Gets a skill by name from the registry
+ *
+ * @param registry - The skill registry
+ * @param name - The skill name (case-insensitive)
+ * @returns The skill info, or undefined if not found
+ */
+export function getSkill(registry: SkillRegistry, name: string): SkillInfo | undefined {
+  return registry.get(name.toLowerCase());
+}

--- a/src/skill-renderer.test.ts
+++ b/src/skill-renderer.test.ts
@@ -1,0 +1,215 @@
+import type { SkillInfo, SkillRegistry } from "./skill-loader.js";
+import { expandSkillTags } from "./skill-renderer.js";
+
+/** Helper to create a SkillInfo from just content */
+function skill(content: string, name = "test"): SkillInfo {
+  return { name, content, source: "global", filePath: "" };
+}
+
+/** Helper to create a registry from [key, content] pairs */
+function createRegistry(entries: [string, string][]): SkillRegistry {
+  return new Map(entries.map(([key, content]) => [key, skill(content, key)]));
+}
+
+describe("expandSkillTags", () => {
+  describe("Block format <skill>name</skill>", () => {
+    it("should expand a single skill tag", () => {
+      const registry = createRegistry([["jira", "Jira skill content"]]);
+
+      const result = expandSkillTags("Use <skill>jira</skill> for tickets", registry);
+
+      expect(result).toBe("Use Jira skill content for tickets");
+    });
+
+    it("should expand multiple skill tags", () => {
+      const registry = createRegistry([
+        ["jira", "Jira skill"],
+        ["github", "GitHub skill"],
+      ]);
+
+      const result = expandSkillTags("<skill>jira</skill> and <skill>github</skill>", registry);
+
+      expect(result).toBe("Jira skill and GitHub skill");
+    });
+
+    it("should leave unknown skills unchanged", () => {
+      const registry = createRegistry([["known", "Known content"]]);
+
+      const result = expandSkillTags("<skill>known</skill> and <skill>unknown</skill>", registry);
+
+      expect(result).toBe("Known content and <skill>unknown</skill>");
+    });
+
+    it("should be case-insensitive for skill names", () => {
+      const registry = createRegistry([["jira", "Jira content"]]);
+
+      const result = expandSkillTags("<skill>JIRA</skill> <skill>Jira</skill>", registry);
+
+      expect(result).toBe("Jira content Jira content");
+    });
+
+    it("should trim whitespace in skill names", () => {
+      const registry = createRegistry([["jira", "Jira content"]]);
+
+      const result = expandSkillTags("<skill>  jira  </skill>", registry);
+
+      expect(result).toBe("Jira content");
+    });
+  });
+
+  describe('Self-closing format <skill name="name" />', () => {
+    it("should expand skill with double quotes", () => {
+      const registry = createRegistry([["jira", "Jira skill content"]]);
+
+      const result = expandSkillTags('Use <skill name="jira" /> for tickets', registry);
+
+      expect(result).toBe("Use Jira skill content for tickets");
+    });
+
+    it("should expand skill with single quotes", () => {
+      const registry = createRegistry([["jira", "Jira skill content"]]);
+
+      const result = expandSkillTags("Use <skill name='jira' /> for tickets", registry);
+
+      expect(result).toBe("Use Jira skill content for tickets");
+    });
+
+    it("should expand skill without space before slash", () => {
+      const registry = createRegistry([["jira", "Jira skill content"]]);
+
+      const result = expandSkillTags('Use <skill name="jira"/> for tickets', registry);
+
+      expect(result).toBe("Use Jira skill content for tickets");
+    });
+
+    it("should expand multiple self-closing tags", () => {
+      const registry = createRegistry([
+        ["jira", "Jira skill"],
+        ["github", "GitHub skill"],
+      ]);
+
+      const result = expandSkillTags('<skill name="jira" /> and <skill name="github" />', registry);
+
+      expect(result).toBe("Jira skill and GitHub skill");
+    });
+
+    it("should leave unknown skills unchanged", () => {
+      const registry = createRegistry([["known", "Known content"]]);
+
+      const result = expandSkillTags(
+        '<skill name="known" /> and <skill name="unknown" />',
+        registry,
+      );
+
+      expect(result).toBe('Known content and <skill name="unknown" />');
+    });
+
+    it("should be case-insensitive for skill names", () => {
+      const registry = createRegistry([["jira", "Jira content"]]);
+
+      const result = expandSkillTags('<skill name="JIRA" /> <skill name="Jira" />', registry);
+
+      expect(result).toBe("Jira content Jira content");
+    });
+  });
+
+  describe("Mixed formats", () => {
+    it("should handle both formats in the same text", () => {
+      const registry = createRegistry([
+        ["jira", "Jira skill"],
+        ["github", "GitHub skill"],
+      ]);
+
+      const result = expandSkillTags('<skill name="jira" /> and <skill>github</skill>', registry);
+
+      expect(result).toBe("Jira skill and GitHub skill");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle empty registry", () => {
+      const registry: SkillRegistry = new Map();
+
+      const result = expandSkillTags("<skill>anything</skill>", registry);
+
+      expect(result).toBe("<skill>anything</skill>");
+    });
+
+    it("should handle text without skill tags", () => {
+      const registry = createRegistry([["jira", "Jira content"]]);
+
+      const result = expandSkillTags("No skill tags here", registry);
+
+      expect(result).toBe("No skill tags here");
+    });
+
+    it("should handle empty text", () => {
+      const registry = createRegistry([["jira", "Jira content"]]);
+
+      const result = expandSkillTags("", registry);
+
+      expect(result).toBe("");
+    });
+
+    it("should preserve multiline skill content", () => {
+      const registry = createRegistry([["jira", "Line 1\nLine 2\nLine 3"]]);
+
+      const result = expandSkillTags("Start\n<skill>jira</skill>\nEnd", registry);
+
+      expect(result).toBe("Start\nLine 1\nLine 2\nLine 3\nEnd");
+    });
+
+    it("should handle skill names with hyphens", () => {
+      const registry = createRegistry([["my-skill", "My skill content"]]);
+
+      const result = expandSkillTags("<skill>my-skill</skill>", registry);
+
+      expect(result).toBe("My skill content");
+    });
+
+    it("should handle skill names with underscores", () => {
+      const registry = createRegistry([["my_skill", "My skill content"]]);
+
+      const result = expandSkillTags('<skill name="my_skill" />', registry);
+
+      expect(result).toBe("My skill content");
+    });
+  });
+
+  describe("Real-world scenarios", () => {
+    it("should expand a Jira skill with custom field mappings", () => {
+      const registry = createRegistry([
+        [
+          "jira",
+          `## Jira Custom Field Mappings
+
+When creating issues, use these field mappings:
+- customfield_16570 => Acceptance Criteria
+- customfield_11401 => Team`,
+        ],
+      ]);
+
+      const result = expandSkillTags("Create a bug ticket in Jira. <skill>jira</skill>", registry);
+
+      expect(result).toContain("Create a bug ticket in Jira.");
+      expect(result).toContain("Jira Custom Field Mappings");
+      expect(result).toContain("customfield_16570");
+    });
+
+    it("should work with snippet-style instructions", () => {
+      const registry = createRegistry([
+        ["careful", "Think step by step and double-check your work."],
+        ["testing", "Always write tests for new functionality."],
+      ]);
+
+      const result = expandSkillTags(
+        "Implement this feature. <skill>careful</skill> <skill>testing</skill>",
+        registry,
+      );
+
+      expect(result).toBe(
+        "Implement this feature. Think step by step and double-check your work. Always write tests for new functionality.",
+      );
+    });
+  });
+});

--- a/src/skill-renderer.ts
+++ b/src/skill-renderer.ts
@@ -1,0 +1,50 @@
+import { PATTERNS } from "./constants.js";
+import { logger } from "./logger.js";
+import type { SkillRegistry } from "./skill-loader.js";
+
+/**
+ * Expands skill tags in text, replacing them with the skill's content body
+ *
+ * Supports two formats:
+ * 1. Self-closing: <skill name="skill-name" />
+ * 2. Block format: <skill>skill-name</skill>
+ *
+ * @param text - The text containing skill tags to expand
+ * @param registry - The skill registry to look up skills
+ * @returns The text with skill tags replaced by their content
+ */
+export function expandSkillTags(text: string, registry: SkillRegistry): string {
+  let expanded = text;
+
+  // Expand self-closing tags: <skill name="skill-name" />
+  PATTERNS.SKILL_TAG_SELF_CLOSING.lastIndex = 0;
+  expanded = expanded.replace(PATTERNS.SKILL_TAG_SELF_CLOSING, (match, name) => {
+    const key = name.trim().toLowerCase();
+    const skill = registry.get(key);
+
+    if (!skill) {
+      logger.warn(`Skill not found: '${name}', leaving tag unchanged`);
+      return match;
+    }
+
+    logger.debug(`Expanded skill tag: ${name}`, { source: skill.source });
+    return skill.content;
+  });
+
+  // Expand block tags: <skill>skill-name</skill>
+  PATTERNS.SKILL_TAG_BLOCK.lastIndex = 0;
+  expanded = expanded.replace(PATTERNS.SKILL_TAG_BLOCK, (match, name) => {
+    const key = name.trim().toLowerCase();
+    const skill = registry.get(key);
+
+    if (!skill) {
+      logger.warn(`Skill not found: '${name}', leaving tag unchanged`);
+      return match;
+    }
+
+    logger.debug(`Expanded skill tag: ${name}`, { source: skill.source });
+    return skill.content;
+  });
+
+  return expanded;
+}


### PR DESCRIPTION
## Summary

Implements skill rendering in snippets as requested in #22.

### Features
- **New experimental flag**: `experimental.skillRendering` (disabled by default)
- **Two syntax options**:
  - Block format: `<skill>jira</skill>`
  - Self-closing: `<skill name="jira" />`
- **Skill loading from standard OpenCode paths**:
  - Global: `~/.config/opencode/skill[s]/<name>/SKILL.md`
  - Project: `.opencode/skill[s]/<name>/SKILL.md`
  - Claude compatibility: `.claude/skills/<name>/SKILL.md`
- **Renders skill body verbatim** (excludes YAML frontmatter)
- **Processing order**: skills → snippets → shell commands

### Usage

1. Enable the feature in your config:
   ```json
   {
     "experimental": {
       "skillRendering": true
     }
   }
   ```

2. Reference skills in your snippets or messages:
   ```markdown
   Create a bug ticket. <skill>jira</skill>
   ```

### Files Changed
- `src/config.ts` - Added `experimental.skillRendering` flag
- `src/constants.ts` - Added skill tag regex patterns
- `src/skill-loader.ts` - New file for loading skills from disk
- `src/skill-renderer.ts` - New file for expanding skill tags
- `src/skill-renderer.test.ts` - Comprehensive test suite
- `index.ts` - Integration of skill loading and rendering
- `schema/config.schema.json` - Updated config schema

Closes #22
