### PR TITLE
fix: correct "plugins" to "plugin" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Add to your `opencode.json` plugins array:
 
 ```json
 {
-  "plugins": [
+  "plugin": [
     "opencode-snippets"
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes a typo in the README installation section: `"plugins"` → `"plugin"` (singular), which is the correct `opencode.json` key.

Closes #26