### PR TITLE
feat: rename snippet commands and add reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,14 @@ Or use the included snippet that expands into `#skill(...)`:
 
 Demo files live at `.opencode/skill/demo-voice/SKILL.md` and `.opencode/snippet/demo-skill.md`.
 
+## Commands
+
+- `/snippets add <name> [content]` creates a global snippet
+- `/snippets add --project <name>` creates a project snippet
+- `/snippets list` shows available snippets
+- `/snippets delete <name>` removes a snippet
+- `/snippets:reload` reloads snippet files from disk without restarting OpenCode
+
 ## Example Snippets
 
 ### `~/.config/opencode/snippet/context.md`

--- a/index.test.ts
+++ b/index.test.ts
@@ -13,7 +13,11 @@ let projectSkillDir: string;
 /** Mock OpenCode plugin context */
 function createMockContext(snippetsDir?: string): PluginInput {
   return {
-    client: {} as PluginInput["client"],
+    client: {
+      session: {
+        prompt: async () => undefined,
+      },
+    } as PluginInput["client"],
     project: {
       id: "test-project",
       worktree: "/test/worktree",
@@ -30,7 +34,11 @@ function createMockContext(snippetsDir?: string): PluginInput {
 /** Create a mock context that uses temp snippet directory */
 function createMockContextWithSnippets(): PluginInput {
   return {
-    client: {} as PluginInput["client"],
+    client: {
+      session: {
+        prompt: async () => undefined,
+      },
+    } as PluginInput["client"],
     project: {
       id: "test-project",
       worktree: join(tempDir, "project"),
@@ -538,7 +546,7 @@ describe("SnippetsPlugin - Hook Integration", () => {
   });
 
   describe("config hook", () => {
-    it("should register /snippet command", async () => {
+    it("should register /snippets commands", async () => {
       const ctx = createMockContext();
       const hooks = await SnippetsPlugin(ctx);
 
@@ -546,8 +554,69 @@ describe("SnippetsPlugin - Hook Integration", () => {
       await hooks.config?.(config as Config);
 
       expect(config.command).toBeDefined();
-      expect(config.command?.snippet).toBeDefined();
-      expect(config.command?.snippet?.description).toContain("snippet");
+      expect(config.command?.snippets).toBeDefined();
+      expect(config.command?.snippets?.description).toContain("snippet");
+      expect(config.command?.["snippets:reload"]).toBeDefined();
+    });
+
+    it("should reload snippets from disk with /snippets:reload", async () => {
+      tempDir = join(import.meta.dir, `.test-snippets-reload-${Date.now()}`);
+      projectSnippetDir = join(tempDir, "project", ".opencode", "snippet");
+      await mkdir(projectSnippetDir, { recursive: true });
+      await writeFile(join(projectSnippetDir, "greeting.md"), "hello");
+
+      const promptCalls: Array<{
+        path: { id: string };
+        body: { noReply: boolean; parts: Part[] };
+      }> = [];
+      const ctx = createMockContextWithSnippets();
+      ctx.client = {
+        session: {
+          prompt: async (input) => {
+            promptCalls.push(
+              input as { path: { id: string }; body: { noReply: boolean; parts: Part[] } },
+            );
+          },
+        },
+      } as PluginInput["client"];
+
+      const hooks = await SnippetsPlugin(ctx);
+      const run = hooks["command.execute.before"];
+      expect(run).toBeDefined();
+
+      await writeFile(join(projectSnippetDir, "new-one.md"), "fresh");
+
+      await expect(
+        run?.({ command: "snippets:reload", sessionID: "test-session", arguments: "" }),
+      ).rejects.toThrow("__SNIPPETS_COMMAND_HANDLED__");
+
+      expect(promptCalls).toHaveLength(1);
+      expect(promptCalls[0]?.path.id).toBe("test-session");
+      expect(promptCalls[0]?.body.parts[0]).toMatchObject({
+        type: "text",
+        ignored: true,
+      });
+
+      const userMessage = {
+        role: "user",
+        content: "Test message",
+      } as unknown as UserMessage;
+
+      const output = {
+        message: userMessage,
+        parts: [{ type: "text", text: "Use #new-one now" }] as Part[],
+      };
+
+      await hooks["chat.message"]?.(
+        {
+          sessionID: "test-session",
+        },
+        output,
+      );
+
+      expect(textOf(output.parts[0])).toBe("Use fresh now");
+
+      await rm(tempDir, { recursive: true, force: true });
     });
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ async function cleanupLegacySkillInstall(): Promise<void> {
  * Snippets Plugin for OpenCode
  *
  * Expands hashtag-based shortcuts in user messages into predefined text snippets.
- * Also provides /snippet command for managing snippets.
+ * Also provides /snippets commands for managing snippets.
  *
  * @see https://github.com/JosXa/opencode-snippets for full documentation
  */
@@ -300,7 +300,7 @@ export const SnippetsPlugin: Plugin = async (ctx) => {
   };
 
   return {
-    // Register /snippet command and skill path
+    // Register /snippets commands and skill path
     config: async (opencodeConfig) => {
       // Register skill folder path for automatic discovery
       const cfg = opencodeConfig as typeof opencodeConfig & {
@@ -310,11 +310,15 @@ export const SnippetsPlugin: Plugin = async (ctx) => {
       cfg.skills.paths ??= [];
       cfg.skills.paths.push(SKILL_DIR);
 
-      // Register /snippet command
+      // Register /snippets commands
       opencodeConfig.command ??= {};
-      opencodeConfig.command.snippet = {
+      opencodeConfig.command.snippets = {
         template: "",
         description: "Manage text snippets (add, delete, list, help)",
+      };
+      opencodeConfig.command["snippets:reload"] = {
+        template: "",
+        description: "Reload snippet files from disk",
       };
     },
 

--- a/skill/snippets/SKILL.md
+++ b/skill/snippets/SKILL.md
@@ -186,10 +186,11 @@ Treat `#skill(...)` as hidden context injection, not inline expansion. User usua
 
 ## Commands
 
-- `/snippet add <name> [content]` - create global snippet
-- `/snippet add --project <name>` - create project snippet
-- `/snippet list` - show all available
-- `/snippet delete <name>` - remove snippet
+- `/snippets add <name> [content]` - create global snippet
+- `/snippets add --project <name>` - create project snippet
+- `/snippets list` - show all available
+- `/snippets delete <name>` - remove snippet
+- `/snippets:reload` - reload snippet files from disk
 
 ## Good Snippets
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -120,7 +120,19 @@ export function createCommandExecuteHandler(
   projectDir?: string,
 ) {
   return async (input: { command: string; sessionID: string; arguments: string }) => {
-    if (input.command !== "snippet") return;
+    if (input.command === "snippets:reload") {
+      await handleReloadCommand({
+        client,
+        sessionId: input.sessionID,
+        args: [],
+        rawArguments: input.arguments,
+        snippets,
+        projectDir,
+      });
+      throw new Error(COMMAND_HANDLED_MARKER);
+    }
+
+    if (input.command !== "snippets") return;
 
     // Use shell-like argument parsing to handle quoted strings correctly
     const args = parseCommandArgs(input.arguments);
@@ -176,7 +188,7 @@ export function createCommandExecuteHandler(
 }
 
 /**
- * Handle /snippet add <name> ["content"] [--project] [--alias=<alias>] [--desc=<description>]
+ * Handle /snippets add <name> ["content"] [--project] [--alias=<alias>] [--desc=<description>]
  */
 async function handleAddCommand(ctx: CommandContext): Promise<void> {
   const { client, sessionId, args, snippets, projectDir } = ctx;
@@ -185,13 +197,13 @@ async function handleAddCommand(ctx: CommandContext): Promise<void> {
     await sendIgnoredMessage(
       client,
       sessionId,
-      'Usage: /snippet add <name> ["content"] [options]\n\n' +
+      'Usage: /snippets add <name> ["content"] [options]\n\n' +
         "Adds a new snippet. Defaults to global directory.\n\n" +
         "Examples:\n" +
-        "  /snippet add greeting\n" +
-        '  /snippet add bye "see you later"\n' +
-        '  /snippet add hi "hello there" --aliases hello,hey\n' +
-        '  /snippet add fix "fix imports" --project\n\n' +
+        "  /snippets add greeting\n" +
+        '  /snippets add bye "see you later"\n' +
+        '  /snippets add hi "hello there" --aliases hello,hey\n' +
+        '  /snippets add fix "fix imports" --project\n\n' +
         "Options:\n" +
         "  --project             Add to project directory (.opencode/snippet/)\n" +
         "  --aliases X,Y,Z       Add aliases (comma-separated)\n" +
@@ -251,7 +263,7 @@ async function handleAddCommand(ctx: CommandContext): Promise<void> {
 }
 
 /**
- * Handle /snippet delete <name>
+ * Handle /snippets delete <name>
  */
 async function handleDeleteCommand(ctx: CommandContext): Promise<void> {
   const { client, sessionId, args, snippets, projectDir } = ctx;
@@ -260,7 +272,7 @@ async function handleDeleteCommand(ctx: CommandContext): Promise<void> {
     await sendIgnoredMessage(
       client,
       sessionId,
-      "Usage: /snippet delete <name>\n\nDeletes a snippet by name. " +
+      "Usage: /snippets delete <name>\n\nDeletes a snippet by name. " +
         "Project snippets are checked first, then global.",
     );
     return;
@@ -283,9 +295,25 @@ async function handleDeleteCommand(ctx: CommandContext): Promise<void> {
     await sendIgnoredMessage(
       client,
       sessionId,
-      `Snippet not found: #${name}\n\nUse /snippet list to see available snippets.`,
+      `Snippet not found: #${name}\n\nUse /snippets list to see available snippets.`,
     );
   }
+}
+
+/**
+ * Handle /snippets:reload
+ */
+async function handleReloadCommand(ctx: CommandContext): Promise<void> {
+  const { client, sessionId, snippets, projectDir } = ctx;
+
+  await reloadSnippets(snippets, projectDir);
+
+  const count = listSnippets(snippets).length;
+  await sendIgnoredMessage(
+    client,
+    sessionId,
+    `Reloaded ${count} snippet${count === 1 ? "" : "s"}.`,
+  );
 }
 
 /** Maximum characters for snippet content preview */
@@ -339,7 +367,7 @@ function formatSnippetEntry(s: { name: string; content: string; aliases: string[
 }
 
 /**
- * Handle /snippet list
+ * Handle /snippets list
  */
 async function handleListCommand(ctx: CommandContext): Promise<void> {
   const { client, sessionId, snippets, projectDir } = ctx;
@@ -355,7 +383,7 @@ async function handleListCommand(ctx: CommandContext): Promise<void> {
         (projectDir
           ? `Project snippets: ${projectSnippetLocations(projectDir)}`
           : "No project directory detected.") +
-        "\n\nUse /snippet add <name> to add a new snippet.",
+        "\n\nUse /snippets add <name> to add a new snippet.",
     );
     return;
   }
@@ -384,14 +412,14 @@ async function handleListCommand(ctx: CommandContext): Promise<void> {
 }
 
 /**
- * Handle /snippet help
+ * Handle /snippets help
  */
 async function handleHelpCommand(ctx: CommandContext): Promise<void> {
   const { client, sessionId } = ctx;
 
   const helpText = `Snippets Command - Manage text snippets
 
-Usage: /snippet <command> [options]
+Usage: /snippets <command> [options]
 
 Commands:
   add <name> ["content"] [options]
@@ -401,6 +429,7 @@ Commands:
 
   delete <name>             Delete a snippet
   list                      List all available snippets
+  /snippets:reload          Reload snippet files from disk
   help                      Show this help message
 
 Snippet Locations:
@@ -412,12 +441,13 @@ Usage in messages:
   Snippets can reference other snippets recursively.
 
 Examples:
-  /snippet add greeting
-  /snippet add bye "see you later"
-  /snippet add hi "hello there" --aliases hello,hey
-  /snippet add fix "fix imports" --project
-  /snippet delete old-snippet
-  /snippet list`;
+  /snippets add greeting
+  /snippets add bye "see you later"
+  /snippets add hi "hello there" --aliases hello,hey
+  /snippets add fix "fix imports" --project
+  /snippets delete old-snippet
+  /snippets list
+  /snippets:reload`;
 
   await sendIgnoredMessage(client, sessionId, helpText);
 }


### PR DESCRIPTION
## Summary

- rename the plugin slash command from `/snippet` to `/snippets` and register a dedicated `/snippets:reload` command
- implement reload by reusing the existing snippet loader path so the in-memory registry is repopulated from disk without restart
- update docs and tests to cover the new command surface and verify reload picks up newly added snippet files
