### PR TITLE
fix: avoid creating redundant snippet/ dir when snippets/ already exists + path tracking refactor

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { parseCommandArgs } from "./arg-parser.js";
-import { getProjectPaths, PATHS } from "./constants.js";
+import { GLOBAL_PATHS, getProjectPaths } from "./constants.js";
 import { createSnippet, deleteSnippet, listSnippets, reloadSnippets } from "./loader.js";
 import { logger } from "./logger.js";
 import { sendIgnoredMessage } from "./notification.js";
@@ -352,12 +352,12 @@ function formatAliases(aliases: string[]): string {
 }
 
 function globalSnippetLocations(): string {
-  return `${PATHS.SNIPPETS_DIR}/ or ${PATHS.SNIPPETS_DIR_ALT}/`;
+  return `${GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED}/ or ${GLOBAL_PATHS.SNIPPETS_DIR_ALT}/`;
 }
 
 function projectSnippetLocations(projectDir: string): string {
   const paths = getProjectPaths(projectDir);
-  return `${paths.SNIPPETS_DIR}/ or ${paths.SNIPPETS_DIR_ALT}/`;
+  return `${paths.SNIPPETS_DIR_PREFERRED}/ or ${paths.SNIPPETS_DIR_ALT}/`;
 }
 
 /**

--- a/src/config.integration.test.ts
+++ b/src/config.integration.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "./config.js";
+import { GLOBAL_PATHS } from "./constants.js";
 import { logger } from "./logger.js";
 
 describe("Config Integration", () => {
@@ -27,22 +28,35 @@ describe("Config Integration", () => {
     logger.debugEnabled = false;
   });
 
+  function withGlobalDir(fn: () => void) {
+    const origPreferred = GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED;
+    const origActive = GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR;
+    const origAlt = GLOBAL_PATHS.SNIPPETS_DIR_ALT;
+    const origConfig = GLOBAL_PATHS.CONFIG_FILE;
+
+    GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED = globalDir;
+    GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR = globalDir;
+    GLOBAL_PATHS.SNIPPETS_DIR_ALT = join(globalDir, ".nonexistent-alt");
+    GLOBAL_PATHS.CONFIG_FILE = join(globalDir, "config.jsonc");
+
+    try {
+      fn();
+    } finally {
+      GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED = origPreferred;
+      GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR = origActive;
+      GLOBAL_PATHS.SNIPPETS_DIR_ALT = origAlt;
+      GLOBAL_PATHS.CONFIG_FILE = origConfig;
+    }
+  }
+
   describe("logging.debug config", () => {
     it("should enable debug logging when config.logging.debug is true", () => {
       writeFileSync(join(globalDir, "config.jsonc"), JSON.stringify({ logging: { debug: true } }));
 
-      // Temporarily override PATHS for this test
-      const originalPaths = require("./constants.js").PATHS;
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = join(globalDir, "config.jsonc");
-      require("./constants.js").PATHS.SNIPPETS_DIR = globalDir;
-
-      const config = loadConfig();
-
-      expect(config.logging.debug).toBe(true);
-
-      // Restore
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = originalPaths.CONFIG_FILE_GLOBAL;
-      require("./constants.js").PATHS.SNIPPETS_DIR = originalPaths.SNIPPETS_DIR;
+      withGlobalDir(() => {
+        const config = loadConfig();
+        expect(config.logging.debug).toBe(true);
+      });
     });
 
     it("should accept 'enabled' string for debug logging", () => {
@@ -51,16 +65,10 @@ describe("Config Integration", () => {
         JSON.stringify({ logging: { debug: "enabled" } }),
       );
 
-      const originalPaths = require("./constants.js").PATHS;
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = join(globalDir, "config.jsonc");
-      require("./constants.js").PATHS.SNIPPETS_DIR = globalDir;
-
-      const config = loadConfig();
-
-      expect(config.logging.debug).toBe(true);
-
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = originalPaths.CONFIG_FILE_GLOBAL;
-      require("./constants.js").PATHS.SNIPPETS_DIR = originalPaths.SNIPPETS_DIR;
+      withGlobalDir(() => {
+        const config = loadConfig();
+        expect(config.logging.debug).toBe(true);
+      });
     });
   });
 
@@ -75,16 +83,10 @@ describe("Config Integration", () => {
         JSON.stringify({ logging: { debug: true } }),
       );
 
-      const originalPaths = require("./constants.js").PATHS;
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = join(globalDir, "config.jsonc");
-      require("./constants.js").PATHS.SNIPPETS_DIR = globalDir;
-
-      const config = loadConfig(projectDir);
-
-      expect(config.logging.debug).toBe(true);
-
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = originalPaths.CONFIG_FILE_GLOBAL;
-      require("./constants.js").PATHS.SNIPPETS_DIR = originalPaths.SNIPPETS_DIR;
+      withGlobalDir(() => {
+        const config = loadConfig(projectDir);
+        expect(config.logging.debug).toBe(true);
+      });
     });
 
     it("should merge partial project config", () => {
@@ -100,17 +102,11 @@ describe("Config Integration", () => {
         JSON.stringify({ logging: { debug: true } }),
       );
 
-      const originalPaths = require("./constants.js").PATHS;
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = join(globalDir, "config.jsonc");
-      require("./constants.js").PATHS.SNIPPETS_DIR = globalDir;
-
-      const config = loadConfig(projectDir);
-
-      expect(config.logging.debug).toBe(true);
-      expect(config.injectRecencyMessages).toBe(9); // inherited from global
-
-      require("./constants.js").PATHS.CONFIG_FILE_GLOBAL = originalPaths.CONFIG_FILE_GLOBAL;
-      require("./constants.js").PATHS.SNIPPETS_DIR = originalPaths.SNIPPETS_DIR;
+      withGlobalDir(() => {
+        const config = loadConfig(projectDir);
+        expect(config.logging.debug).toBe(true);
+        expect(config.injectRecencyMessages).toBe(9); // inherited from global
+      });
     });
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,17 +2,20 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getGlobalConfigPath, getProjectConfigPath, loadConfig } from "./config.js";
-import { PATHS } from "./constants.js";
+import { GLOBAL_PATHS } from "./constants.js";
 
 // Use temp directories for testing to avoid affecting real config
 const TEST_TEMP_DIR = join(import.meta.dirname ?? ".", ".test-temp-config");
 const TEST_GLOBAL_SNIPPETS_DIR = join(TEST_TEMP_DIR, "global", "snippet");
+const TEST_GLOBAL_SNIPPETS_DIR_ALT = join(TEST_TEMP_DIR, "global", "snippets"); // nonexistent
 const TEST_PROJECT_DIR = join(TEST_TEMP_DIR, "project");
 const TEST_PROJECT_SNIPPETS_DIR = join(TEST_PROJECT_DIR, ".opencode", "snippet");
+const TEST_GLOBAL_CONFIG_FILE = join(TEST_GLOBAL_SNIPPETS_DIR, "config.jsonc");
 
-// Store original PATHS values to restore after tests
-const originalSnippetsDir = PATHS.SNIPPETS_DIR;
-const originalConfigFileGlobal = (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL;
+// Store original GLOBAL_PATHS values to restore after tests
+const originalActiveSnippetsDir = GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR;
+const originalSnippetsDirAlt = GLOBAL_PATHS.SNIPPETS_DIR_ALT;
+const originalConfigFile = GLOBAL_PATHS.CONFIG_FILE;
 
 describe("config", () => {
   beforeEach(() => {
@@ -25,28 +28,38 @@ describe("config", () => {
     mkdirSync(TEST_GLOBAL_SNIPPETS_DIR, { recursive: true });
     mkdirSync(TEST_PROJECT_SNIPPETS_DIR, { recursive: true });
 
-    // Override PATHS for testing (using Object.defineProperty since PATHS is readonly)
-    Object.defineProperty(PATHS, "SNIPPETS_DIR", {
+    // Override GLOBAL_PATHS for testing (using Object.defineProperty since GLOBAL_PATHS is readonly)
+    Object.defineProperty(GLOBAL_PATHS, "ACTIVE_SNIPPETS_DIR", {
       value: TEST_GLOBAL_SNIPPETS_DIR,
       writable: true,
       configurable: true,
     });
-    Object.defineProperty(PATHS, "CONFIG_FILE_GLOBAL", {
-      value: join(TEST_GLOBAL_SNIPPETS_DIR, "config.jsonc"),
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_ALT", {
+      value: TEST_GLOBAL_SNIPPETS_DIR_ALT, // nonexistent, so alt is never chosen
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_FILE", {
+      value: TEST_GLOBAL_CONFIG_FILE,
       writable: true,
       configurable: true,
     });
   });
 
   afterEach(() => {
-    // Restore original PATHS
-    Object.defineProperty(PATHS, "SNIPPETS_DIR", {
-      value: originalSnippetsDir,
+    // Restore original GLOBAL_PATHS
+    Object.defineProperty(GLOBAL_PATHS, "ACTIVE_SNIPPETS_DIR", {
+      value: originalActiveSnippetsDir,
       writable: true,
       configurable: true,
     });
-    Object.defineProperty(PATHS, "CONFIG_FILE_GLOBAL", {
-      value: originalConfigFileGlobal,
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_ALT", {
+      value: originalSnippetsDirAlt,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_FILE", {
+      value: originalConfigFile,
       writable: true,
       configurable: true,
     });
@@ -70,20 +83,16 @@ describe("config", () => {
 
     it("should auto-create global config file when it doesn't exist", () => {
       // Config file should not exist initially
-      expect(existsSync((PATHS as Record<string, string>).CONFIG_FILE_GLOBAL)).toBe(false);
+      expect(existsSync(TEST_GLOBAL_CONFIG_FILE)).toBe(false);
 
       loadConfig();
 
       // Config file should be created
-      expect(existsSync((PATHS as Record<string, string>).CONFIG_FILE_GLOBAL)).toBe(true);
+      expect(existsSync(TEST_GLOBAL_CONFIG_FILE)).toBe(true);
     });
 
     it("should load global config file", () => {
-      writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
-        JSON.stringify({ logging: { debug: true } }),
-        "utf-8",
-      );
+      writeFileSync(TEST_GLOBAL_CONFIG_FILE, JSON.stringify({ logging: { debug: true } }), "utf-8");
 
       const config = loadConfig();
 
@@ -98,7 +107,7 @@ describe("config", () => {
           "debug": true
         }
       }`;
-      writeFileSync((PATHS as Record<string, string>).CONFIG_FILE_GLOBAL, jsoncContent, "utf-8");
+      writeFileSync(TEST_GLOBAL_CONFIG_FILE, jsoncContent, "utf-8");
 
       const config = loadConfig();
 
@@ -107,7 +116,7 @@ describe("config", () => {
 
     it("should accept 'enabled' string for debug", () => {
       writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
+        TEST_GLOBAL_CONFIG_FILE,
         JSON.stringify({ logging: { debug: "enabled" } }),
         "utf-8",
       );
@@ -119,7 +128,7 @@ describe("config", () => {
 
     it("should accept 'disabled' string for debug", () => {
       writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
+        TEST_GLOBAL_CONFIG_FILE,
         JSON.stringify({ logging: { debug: "disabled" } }),
         "utf-8",
       );
@@ -131,11 +140,7 @@ describe("config", () => {
 
     it("should merge partial config with defaults", () => {
       // Only set debug, other options should use default
-      writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
-        JSON.stringify({ logging: { debug: true } }),
-        "utf-8",
-      );
+      writeFileSync(TEST_GLOBAL_CONFIG_FILE, JSON.stringify({ logging: { debug: true } }), "utf-8");
 
       const config = loadConfig();
 
@@ -145,11 +150,7 @@ describe("config", () => {
 
     it("should merge project config with global config (project has priority)", () => {
       // Global config
-      writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
-        JSON.stringify({ logging: { debug: true } }),
-        "utf-8",
-      );
+      writeFileSync(TEST_GLOBAL_CONFIG_FILE, JSON.stringify({ logging: { debug: true } }), "utf-8");
 
       // Project config (overrides global)
       const projectConfigPath = join(TEST_PROJECT_SNIPPETS_DIR, "config.jsonc");
@@ -161,11 +162,7 @@ describe("config", () => {
     });
 
     it("should handle malformed JSONC gracefully", () => {
-      writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
-        "{ invalid json }",
-        "utf-8",
-      );
+      writeFileSync(TEST_GLOBAL_CONFIG_FILE, "{ invalid json }", "utf-8");
 
       const config = loadConfig();
 
@@ -179,7 +176,7 @@ describe("config", () => {
 
     it("should load experimental skill loading config", () => {
       writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
+        TEST_GLOBAL_CONFIG_FILE,
         JSON.stringify({ experimental: { skillLoading: true } }),
         "utf-8",
       );
@@ -191,7 +188,7 @@ describe("config", () => {
 
     it("should ignore invalid config value types", () => {
       writeFileSync(
-        (PATHS as Record<string, string>).CONFIG_FILE_GLOBAL,
+        TEST_GLOBAL_CONFIG_FILE,
         JSON.stringify({ logging: { debug: "yes" } }),
         "utf-8",
       );
@@ -206,7 +203,7 @@ describe("config", () => {
   describe("getGlobalConfigPath", () => {
     it("should return the global config path", () => {
       const path = getGlobalConfigPath();
-      expect(path).toBe((PATHS as Record<string, string>).CONFIG_FILE_GLOBAL);
+      expect(path).toBe(TEST_GLOBAL_CONFIG_FILE);
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { importCjs } from "./cjs-interop.js";
-import { getProjectPaths, PATHS } from "./constants.js";
+import { GLOBAL_PATHS, getProjectPaths } from "./constants.js";
 import { logger } from "./logger.js";
 
 const { parse: parseJsonc } = await importCjs<typeof import("jsonc-parser")>("jsonc-parser");
@@ -159,15 +159,15 @@ function parseJsoncFile(filePath: string): RawConfig {
  */
 function ensureGlobalConfigExists(): void {
   // Create snippets directory if it doesn't exist
-  if (!existsSync(PATHS.SNIPPETS_DIR)) {
-    mkdirSync(PATHS.SNIPPETS_DIR, { recursive: true });
-    logger.debug("Created global snippets directory", { path: PATHS.SNIPPETS_DIR });
+  if (!existsSync(GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR)) {
+    mkdirSync(GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR, { recursive: true });
+    logger.debug("Created global snippets directory", { path: GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR });
   }
 
   // Create default config file if it doesn't exist
-  if (!existsSync(PATHS.CONFIG_FILE_GLOBAL)) {
-    writeFileSync(PATHS.CONFIG_FILE_GLOBAL, DEFAULT_CONFIG_CONTENT, "utf-8");
-    logger.debug("Created default config file", { path: PATHS.CONFIG_FILE_GLOBAL });
+  if (!existsSync(GLOBAL_PATHS.CONFIG_FILE)) {
+    writeFileSync(GLOBAL_PATHS.CONFIG_FILE, DEFAULT_CONFIG_CONTENT, "utf-8");
+    logger.debug("Created default config file", { path: GLOBAL_PATHS.CONFIG_FILE });
   }
 }
 
@@ -190,10 +190,10 @@ export function loadConfig(projectDir?: string): SnippetsConfig {
   let config: SnippetsConfig = structuredClone(DEFAULT_CONFIG);
 
   // Load global config
-  if (existsSync(PATHS.CONFIG_FILE_GLOBAL)) {
-    const globalConfig = parseJsoncFile(PATHS.CONFIG_FILE_GLOBAL);
+  if (existsSync(GLOBAL_PATHS.CONFIG_FILE)) {
+    const globalConfig = parseJsoncFile(GLOBAL_PATHS.CONFIG_FILE);
     config = mergeConfig(config, globalConfig);
-    logger.debug("Loaded global config", { path: PATHS.CONFIG_FILE_GLOBAL });
+    logger.debug("Loaded global config", { path: GLOBAL_PATHS.CONFIG_FILE });
   }
 
   // Load project config if project directory is provided
@@ -247,7 +247,7 @@ function mergeConfig(base: SnippetsConfig, raw: RawConfig): SnippetsConfig {
  * Get the path to the global config file
  */
 export function getGlobalConfigPath(): string {
-  return PATHS.CONFIG_FILE_GLOBAL;
+  return GLOBAL_PATHS.CONFIG_FILE;
 }
 
 /**

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveSnippetDir } from "./constants.js";
+
+describe("resolveSnippetDir", () => {
+  let tmp: string;
+  let preferred: string;
+  let alt: string;
+
+  beforeEach(() => {
+    tmp = join(tmpdir(), `resolve-snippet-dir-${Date.now()}`);
+    preferred = join(tmp, "snippet");
+    alt = join(tmp, "snippets");
+    mkdirSync(tmp, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("neither exists, use preferred dir (will be created)", () => {
+    expect(resolveSnippetDir(preferred, alt)).toBe(preferred);
+  });
+
+  it("only alt exists, use alt dir (avoids creating redundant preferred dir)", () => {
+    mkdirSync(alt);
+    expect(resolveSnippetDir(preferred, alt)).toBe(alt);
+  });
+
+  it("only preferred exists, use preferred dir", () => {
+    mkdirSync(preferred);
+    expect(resolveSnippetDir(preferred, alt)).toBe(preferred);
+  });
+
+  it("both exist, use preferred dir", () => {
+    mkdirSync(preferred);
+    mkdirSync(alt);
+    expect(resolveSnippetDir(preferred, alt)).toBe(preferred);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -24,33 +25,71 @@ export const PATTERNS = {
 } as const;
 
 /**
- * File system paths
+ * Resolved paths for a snippet scope (global or project).
  */
-export const PATHS = {
-  /** OpenCode configuration directory */
-  CONFIG_DIR: join(homedir(), ".config", "opencode"),
-
-  /** Preferred global snippets directory */
-  SNIPPETS_DIR: join(homedir(), ".config", "opencode", "snippet"),
-
-  /** Alternate global snippets directory */
-  SNIPPETS_DIR_ALT: join(homedir(), ".config", "opencode", "snippets"),
-
-  /** Global config file */
-  CONFIG_FILE_GLOBAL: join(homedir(), ".config", "opencode", "snippet", "config.jsonc"),
-} as const;
+export interface SnippetPaths {
+  /** OpenCode configuration directory for the scope (e.g. ~/.config/opencode or projectDir/.opencode) */
+  CONFIG_DIR: string;
+  /** Canonical preferred snippets directory */
+  SNIPPETS_DIR_PREFERRED: string;
+  /** Alternate snippets directory */
+  SNIPPETS_DIR_ALT: string;
+  /** Resolved active snippets directory: preferred, unless only alt exists */
+  ACTIVE_SNIPPETS_DIR: string;
+  /** Config file path inside ACTIVE_SNIPPETS_DIR */
+  CONFIG_FILE: string;
+}
 
 /**
- * Get project-specific paths based on project directory
+ * Resolve the active snippets directory for writing/init.
+ *
+ * Uses alt only when it already exists and preferred does not
+ * This avoids creating a redundant snippet/ dir next to an existing snippets/ dir.
+ * Falls back to preferred in all other cases (including creation).
  */
-export function getProjectPaths(projectDir: string) {
-  const snippetDir = join(projectDir, ".opencode", "snippet");
+export function resolveSnippetDir(preferred: string, alt: string): string {
+  if (existsSync(alt) && !existsSync(preferred)) return alt;
+  return preferred;
+}
+
+/**
+ * Get global paths.
+ */
+function getGlobalPaths(): SnippetPaths {
+  const configDir = join(homedir(), ".config", "opencode");
+  const preferred = join(configDir, "snippet");
+  const alt = join(configDir, "snippets");
+  const active = resolveSnippetDir(preferred, alt);
   return {
-    SNIPPETS_DIR: snippetDir,
-    SNIPPETS_DIR_ALT: join(projectDir, ".opencode", "snippets"),
-    CONFIG_FILE: join(snippetDir, "config.jsonc"),
+    CONFIG_DIR: configDir,
+    SNIPPETS_DIR_PREFERRED: preferred,
+    SNIPPETS_DIR_ALT: alt,
+    ACTIVE_SNIPPETS_DIR: active,
+    CONFIG_FILE: join(active, "config.jsonc"),
   };
 }
+
+/**
+ * Get project-specific paths based on project directory.
+ */
+export function getProjectPaths(projectDir: string): SnippetPaths {
+  const configDir = join(projectDir, ".opencode");
+  const preferred = join(configDir, "snippet");
+  const alt = join(configDir, "snippets");
+  const active = resolveSnippetDir(preferred, alt);
+  return {
+    CONFIG_DIR: configDir,
+    SNIPPETS_DIR_PREFERRED: preferred,
+    SNIPPETS_DIR_ALT: alt,
+    ACTIVE_SNIPPETS_DIR: active,
+    CONFIG_FILE: join(active, "config.jsonc"),
+  };
+}
+
+/**
+ * Global file system paths, computed once at startup.
+ */
+export const GLOBAL_PATHS = getGlobalPaths();
 
 /**
  * Plugin configuration

--- a/src/loader.test.ts
+++ b/src/loader.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "../src/constants.js";
+import { GLOBAL_PATHS } from "../src/constants.js";
 import { createSnippet, deleteSnippet, ensureSnippetsDir, loadSnippets } from "../src/loader.js";
 
 describe("loadSnippets - Dual Path Support", () => {
@@ -11,8 +11,9 @@ describe("loadSnippets - Dual Path Support", () => {
   let projectDir: string;
   let projectSnippetDir: string;
   let projectSnippetsDir: string;
-  const originalGlobalSnippetDir = PATHS.SNIPPETS_DIR;
-  const originalGlobalSnippetsDir = PATHS.SNIPPETS_DIR_ALT;
+  const originalGlobalSnippetDir = GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED;
+  const originalGlobalSnippetsDir = GLOBAL_PATHS.SNIPPETS_DIR_ALT;
+  const originalActiveSnippetsDir = GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR;
 
   beforeEach(async () => {
     // Create temporary directories for testing
@@ -26,26 +27,36 @@ describe("loadSnippets - Dual Path Support", () => {
     await mkdir(globalSnippetDir, { recursive: true });
     await mkdir(projectSnippetDir, { recursive: true });
 
-    Object.defineProperty(PATHS, "SNIPPETS_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_PREFERRED", {
       value: globalSnippetDir,
       writable: true,
       configurable: true,
     });
-    Object.defineProperty(PATHS, "SNIPPETS_DIR_ALT", {
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_ALT", {
       value: globalSnippetsDir,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(GLOBAL_PATHS, "ACTIVE_SNIPPETS_DIR", {
+      value: globalSnippetDir,
       writable: true,
       configurable: true,
     });
   });
 
   afterEach(async () => {
-    Object.defineProperty(PATHS, "SNIPPETS_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_PREFERRED", {
       value: originalGlobalSnippetDir,
       writable: true,
       configurable: true,
     });
-    Object.defineProperty(PATHS, "SNIPPETS_DIR_ALT", {
+    Object.defineProperty(GLOBAL_PATHS, "SNIPPETS_DIR_ALT", {
       value: originalGlobalSnippetsDir,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(GLOBAL_PATHS, "ACTIVE_SNIPPETS_DIR", {
+      value: originalActiveSnippetsDir,
       writable: true,
       configurable: true,
     });
@@ -406,6 +417,13 @@ Hello there!`,
     it("reuses an existing plural global directory", async () => {
       await rm(globalSnippetDir, { recursive: true, force: true });
       await mkdir(globalSnippetsDir, { recursive: true });
+
+      // ACTIVE_SNIPPETS_DIR is fixed at startup; simulate alt-only scenario by mocking it
+      Object.defineProperty(GLOBAL_PATHS, "ACTIVE_SNIPPETS_DIR", {
+        value: globalSnippetsDir,
+        writable: true,
+        configurable: true,
+      });
 
       const filePath = await createSnippet("plural-global", "Plural global content");
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,44 +1,27 @@
-import { access, mkdir, readdir, unlink } from "node:fs/promises";
+import { mkdir, readdir, unlink } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { importCjs } from "./cjs-interop.js";
 
 const matter = await importCjs<typeof import("gray-matter")>("gray-matter");
 
-import { CONFIG, getProjectPaths, PATHS } from "./constants.js";
+import { CONFIG, GLOBAL_PATHS, getProjectPaths } from "./constants.js";
 import { logger } from "./logger.js";
 import type { SnippetFrontmatter, SnippetInfo, SnippetRegistry } from "./types.js";
 
 function getGlobalSnippetDirs(globalDir?: string): string[] {
   if (globalDir) return [globalDir];
 
-  return [PATHS.SNIPPETS_DIR_ALT, PATHS.SNIPPETS_DIR];
+  return [GLOBAL_PATHS.SNIPPETS_DIR_ALT, GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED];
 }
 
 function getProjectSnippetDirs(projectDir: string): string[] {
   const paths = getProjectPaths(projectDir);
-  return [paths.SNIPPETS_DIR_ALT, paths.SNIPPETS_DIR];
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
+  return [paths.SNIPPETS_DIR_ALT, paths.SNIPPETS_DIR_PREFERRED];
 }
 
 async function resolveWritableSnippetDir(projectDir?: string): Promise<string> {
-  const paths = projectDir
-    ? getProjectPaths(projectDir)
-    : { SNIPPETS_DIR: PATHS.SNIPPETS_DIR, SNIPPETS_DIR_ALT: PATHS.SNIPPETS_DIR_ALT };
-
-  // Support both snippet/ and snippets/. Reuse an existing directory first, then default to snippet/.
-  for (const dir of [paths.SNIPPETS_DIR, paths.SNIPPETS_DIR_ALT]) {
-    if (await pathExists(dir)) return dir;
-  }
-
-  return paths.SNIPPETS_DIR;
+  if (projectDir) return getProjectPaths(projectDir).ACTIVE_SNIPPETS_DIR;
+  return GLOBAL_PATHS.ACTIVE_SNIPPETS_DIR;
 }
 
 /**
@@ -265,7 +248,7 @@ export async function deleteSnippet(name: string, projectDir?: string): Promise<
   // Try project directory first if provided
   if (projectDir) {
     const paths = getProjectPaths(projectDir);
-    for (const dir of [paths.SNIPPETS_DIR, paths.SNIPPETS_DIR_ALT]) {
+    for (const dir of [paths.SNIPPETS_DIR_PREFERRED, paths.SNIPPETS_DIR_ALT]) {
       const filePath = join(dir, `${name}${CONFIG.SNIPPET_EXTENSION}`);
       try {
         await unlink(filePath);
@@ -278,7 +261,7 @@ export async function deleteSnippet(name: string, projectDir?: string): Promise<
   }
 
   // Try global directory
-  for (const dir of [PATHS.SNIPPETS_DIR, PATHS.SNIPPETS_DIR_ALT]) {
+  for (const dir of [GLOBAL_PATHS.SNIPPETS_DIR_PREFERRED, GLOBAL_PATHS.SNIPPETS_DIR_ALT]) {
     const filePath = join(dir, `${name}${CONFIG.SNIPPET_EXTENSION}`);
     try {
       await unlink(filePath);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,13 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import { PATHS } from "./constants.js";
+import { GLOBAL_PATHS } from "./constants.js";
 
 export class Logger {
   private logDir: string;
   debugEnabled: boolean;
 
   constructor(logDirOverride?: string, debugEnabled = false) {
-    this.logDir = logDirOverride ?? join(PATHS.CONFIG_DIR, "logs", "snippets");
+    this.logDir = logDirOverride ?? join(GLOBAL_PATHS.CONFIG_DIR, "logs", "snippets");
     this.debugEnabled = debugEnabled;
   }
 

--- a/src/pending-drafts.test.ts
+++ b/src/pending-drafts.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "../src/constants.js";
+import { GLOBAL_PATHS } from "../src/constants.js";
 import {
   addPendingDraft,
   getPendingDrafts,
@@ -15,13 +15,13 @@ function snippet(name: string, content: string): SnippetInfo {
 
 describe("pending draft reloads", () => {
   let tempDir: string;
-  const originalConfigDir = PATHS.CONFIG_DIR;
+  const originalConfigDir = GLOBAL_PATHS.CONFIG_DIR;
 
   beforeEach(async () => {
     tempDir = join(process.cwd(), ".test-pending-drafts");
     await mkdir(tempDir, { recursive: true });
 
-    Object.defineProperty(PATHS, "CONFIG_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_DIR", {
       value: tempDir,
       writable: true,
       configurable: true,
@@ -29,7 +29,7 @@ describe("pending draft reloads", () => {
   });
 
   afterEach(async () => {
-    Object.defineProperty(PATHS, "CONFIG_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_DIR", {
       value: originalConfigDir,
       writable: true,
       configurable: true,

--- a/src/pending-drafts.ts
+++ b/src/pending-drafts.ts
@@ -1,13 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS, PATTERNS } from "./constants.js";
+import { GLOBAL_PATHS, PATTERNS } from "./constants.js";
 import { logger } from "./logger.js";
 import type { SnippetRegistry } from "./types.js";
 
 type PendingDraftState = Record<string, string[]>;
 
 function statePath(): string {
-  return join(PATHS.CONFIG_DIR, "state", "pending-drafts.json");
+  return join(GLOBAL_PATHS.CONFIG_DIR, "state", "pending-drafts.json");
 }
 
 function scopeKey(workspaceDir?: string): string {
@@ -50,7 +50,7 @@ async function readState(): Promise<PendingDraftState> {
 }
 
 async function writeState(state: PendingDraftState): Promise<void> {
-  await mkdir(join(PATHS.CONFIG_DIR, "state"), { recursive: true });
+  await mkdir(join(GLOBAL_PATHS.CONFIG_DIR, "state"), { recursive: true });
   await Bun.write(statePath(), `${JSON.stringify(state, null, 2)}\n`);
 }
 

--- a/src/reload-signal.test.ts
+++ b/src/reload-signal.test.ts
@@ -1,18 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "../src/constants.js";
+import { GLOBAL_PATHS } from "../src/constants.js";
 import { consumeSnippetReloadRequest, markSnippetReloadRequested } from "../src/reload-signal.js";
 
 describe("snippet reload signal", () => {
   let tempDir: string;
-  const originalConfigDir = PATHS.CONFIG_DIR;
+  const originalConfigDir = GLOBAL_PATHS.CONFIG_DIR;
 
   beforeEach(async () => {
     tempDir = join(process.cwd(), ".test-reload-signal");
     await mkdir(tempDir, { recursive: true });
 
-    Object.defineProperty(PATHS, "CONFIG_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_DIR", {
       value: tempDir,
       writable: true,
       configurable: true,
@@ -20,7 +20,7 @@ describe("snippet reload signal", () => {
   });
 
   afterEach(async () => {
-    Object.defineProperty(PATHS, "CONFIG_DIR", {
+    Object.defineProperty(GLOBAL_PATHS, "CONFIG_DIR", {
       value: originalConfigDir,
       writable: true,
       configurable: true,

--- a/src/reload-signal.ts
+++ b/src/reload-signal.ts
@@ -1,12 +1,12 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "./constants.js";
+import { GLOBAL_PATHS } from "./constants.js";
 import { logger } from "./logger.js";
 
 type ReloadSignalState = Record<string, number>;
 
 function statePath(): string {
-  return join(PATHS.CONFIG_DIR, "state", "snippet-reload.json");
+  return join(GLOBAL_PATHS.CONFIG_DIR, "state", "snippet-reload.json");
 }
 
 function scopeKey(workspaceDir?: string): string {
@@ -39,7 +39,7 @@ async function readState(): Promise<ReloadSignalState> {
 }
 
 async function writeState(state: ReloadSignalState): Promise<void> {
-  await mkdir(join(PATHS.CONFIG_DIR, "state"), { recursive: true });
+  await mkdir(join(GLOBAL_PATHS.CONFIG_DIR, "state"), { recursive: true });
   await Bun.write(statePath(), `${JSON.stringify(state, null, 2)}\n`);
 }
 


### PR DESCRIPTION
Hello! I'm trying your plugin and really liking it!

⚠️ However, I've found a bug:
If you already have a `snippets/` directory (with a config inside or not), the plugin creates a brand new `snippet/` directory and drops a fresh config there on every startup, completely ignoring my existing `snippets/` directory..

This PR fixes this! 🚀
I ended up doing a small refactor around path handling, which felt necessary to make the fix clean.

The old `PATHS` constant didn't distinguish between the *preferred* dir, the *alt* dir, and the *currently active* one, I think that ambiguity was the root cause of the bug. 🤔
👉 I replaced it with a `GLOBAL_PATHS` object typed as `SnippetPaths`, which makes all three explicit.

The selection logic lives in a small pure function `resolveSnippetDir(preferred, alt)` that's easy to test in isolation (which I did).
The new `GLOBAL_PATHS` is populated once on startup with `getGlobalPaths` which works the same way as `getProjectPaths`, with the new active dir selection.

The same fix applies to project-scoped paths (`.opencode/snippet/` vs `.opencode/snippets/`), which had the same issue.

Existing tests have been updated, and all 341 tests pass!

---

One thing I noticed while digging around: `writeState` writes runtime state into the config directory.
This feels like it goes against XDG conventions, and runtime state probably belongs in `$XDG_STATE_HOME` (or `$XDG_RUNTIME_DIR` for truly ephemeral data) instead of `$XDG_CONFIG_HOME`.
👉 Happy to make a separate PR if you think this is a good idea!