### PR TITLE
fix: support unicode snippet names in hashtag expansion

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
  */
 export const PATTERNS = {
   /** Matches hashtags like #snippet-name */
-  HASHTAG: /#([a-z0-9\-_]+)/gi,
+  HASHTAG: /#([\p{L}\p{N}\-_]+)/giu,
 
   /** Matches shell commands like !`command` or !>`command` */
   SHELL_COMMAND: /(!>?)`([^`]+)`/g,


### PR DESCRIPTION
HASHTAG regex only matched [a-z0-9\-_], silently skipping non-ASCII names like #提交代码. Switch to Unicode property escapes (\p{L}\p{N}) with the u flag so CJK and other scripts expand correctly.